### PR TITLE
Automated build and release

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,28 @@
+name: Rust
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        type: string
+        required: true
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - run: sudo apt-get install gcc-multilib -y
+    - run: rustup target add i686-unknown-linux-gnu
+    - run: cargo build --release --verbose
+    - uses: svenstaro/upload-release-action@v2
+      with:
+        file: target/i686-unknown-linux-gnu/release/libextest.so
+        tag: ${{ inputs.tag || github.ref }}
+        overwrite: true


### PR DESCRIPTION
Steam Deck's read-only root partition and misconfigured repositories makes getting the build environment for this library rather difficult. This PR adds a github actions file that will automatically build and upload the library whenever a new release is published or on-demand, so that Steam Deck users can skip that step.